### PR TITLE
feat: only enable npm provenance for public repos

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -81,4 +81,4 @@ jobs:
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_CONFIG_PROVENANCE: ${{ github.event.repository.visibility == 'public' }}
+          NPM_CONFIG_PROVENANCE: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -81,4 +81,4 @@ jobs:
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: ${{ github.event.repository.visibility == 'public' }}


### PR DESCRIPTION
Sigstore provenance only supports public source repositories. This makes provenance conditional on repo visibility so private repos can publish without it.