### PR TITLE
feat(changesets): allow customizing version PR title and commit message

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -7,6 +7,16 @@ on:
         required: false
         description: "Needed for using turborepo with remote caching"
         type: string
+      versionPrTitle:
+        required: false
+        description: "Title for the Version Packages pull request. Set to e.g. 'chore: version packages' to satisfy conventional-commit PR title checks."
+        type: string
+        default: "Version Packages"
+      versionCommitMessage:
+        required: false
+        description: "Commit message for the version bump commit. Recommend matching versionPrTitle when overriding it."
+        type: string
+        default: "Version Packages"
     secrets:
       ECOSPARK_APP_ID:
         required: true
@@ -78,6 +88,8 @@ jobs:
         uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1.6.0
         with:
           publish: pnpm release
+          title: ${{ inputs.versionPrTitle }}
+          commit: ${{ inputs.versionCommitMessage }}
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What

Adds two optional `workflow_call` inputs to the shared `changesets.yml` reusable workflow:

- `versionPrTitle` - title for the "Version Packages" PR
- `versionCommitMessage` - commit message for the version bump commit

Both are passed through to `changesets/action`'s `title` and `commit` inputs.

## Why

Repos that run a conventional-commit PR title check (e.g. `amannn/action-semantic-pull-request`) currently fail on the Version Packages PR, because changesets titles it `Version Packages` - not conventional-commit format. Today the only workaround is to stop using this shared workflow and inline the whole job (as sanity-io/cli does) just to pass `title`/`commit`. These inputs let callers stay on the shared workflow and set e.g.:

```yaml
jobs:
  release:
    uses: sanity-io/.github/.github/workflows/changesets.yml@main
    with:
      versionPrTitle: 'chore: version packages'
      versionCommitMessage: 'chore: version packages'
    secrets: inherit
```

Context: sanity-io/get-it#593 inlined the workflow for exactly this reason - with this change it could go back to the thin shared-workflow call.

## Safety

Both inputs default to `"Version Packages"`, which is the same value `changesets/action` uses when `title`/`commit` are omitted. So passing them explicitly with the defaults is identical to the previous behavior, and existing callers that set neither are completely unaffected.

## Note / open question

I defaulted to preserving current behavior (opt-in per repo). If we'd prefer conventional commits org-wide, we could instead default both to `chore: version packages` - that would be a behavior change for all current callers' release PRs, so I left it opt-in. Happy to flip the default if that's the preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)