### PR TITLE
ci(workflows): migrate setup bootstrap to pnpm/setup@v1

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -68,13 +68,12 @@ jobs:
         run: |
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: pnpm/setup@v1
         with:
-          cache: pnpm
-          check-latest: true
-          node-version: lts/*
-        # temporary until setup-node action comes with npm version that contains oidc setup by default
+          install: false
+          cache: true
+          runtime: node@lts
+      # temporary until the runtime ships an npm version with OIDC setup by default
       - name: Update npm to use trusted publishing (OIDC)
         run: npm install -g npm@latest
       - name: Authenticate with private npm

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,12 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: pnpm/setup@v1
         with:
-          cache: pnpm
-          node-version: lts/*
-      - run: pnpm install
+          cache: true
+          runtime: node@lts
       - run: pnpm format
       - run: git restore .github/workflows pnpm-lock.yaml
       - uses: actions/create-github-app-token@v2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Ports the CI setup pattern from [`sanity-io/sanity#13233`](https://github.com/sanity-io/sanity/pull/13233) (and its `portabletext/.github#19` counterpart) into this repo: replace the split `pnpm/action-setup` + `actions/setup-node` bootstrap with a single `pnpm/setup@v1` step that handles pnpm install, the JavaScript runtime, and store caching in one place.

- **`.github/workflows/changesets.yml`**
  - Switched from `pnpm/action-setup@v4` + `actions/setup-node@v6` to a single `pnpm/setup@v1` step.
  - Enabled pnpm store caching via `cache: true` and declared the runtime through `runtime: node@lts` (preserving the existing LTS behavior).
  - Set `install: false` since dependency installation happens in a later explicit `pnpm install` step (after npm auth is configured).

- **`.github/workflows/format.yml`**
  - Switched to `pnpm/setup@v1` with `cache: true` and `runtime: node@lts`.
  - Dropped the standalone `pnpm install` step since `pnpm/setup@v1` runs `pnpm install` by default.

### What to review

- Confirm `runtime: node@lts` is the desired behavior versus the previous `node-version: lts/*` + `check-latest: true`.
- Confirm dropping the explicit `pnpm install` in `format.yml` is acceptable (handled by `pnpm/setup@v1`'s default install).
- `changesets-from-conventional-commits.yml` needs no changes (it does not set up pnpm/node).

### Testing

CI-only change; will be validated by the workflows running on this PR and subsequent releases.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9cab798-4dad-45b0-8497-448564fe99f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9cab798-4dad-45b0-8497-448564fe99f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

