### PR TITLE
Revert "ci(workflows): migrate setup bootstrap to pnpm/setup@v1"

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -68,12 +68,13 @@ jobs:
         run: |
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-      - uses: pnpm/setup@v1
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
         with:
-          install: false
-          cache: true
-          runtime: node@lts
-      # temporary until the runtime ships an npm version with OIDC setup by default
+          cache: pnpm
+          check-latest: true
+          node-version: lts/*
+        # temporary until setup-node action comes with npm version that contains oidc setup by default
       - name: Update npm to use trusted publishing (OIDC)
         run: npm install -g npm@latest
       - name: Authenticate with private npm

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,10 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/setup@v1
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
         with:
-          cache: true
-          runtime: node@lts
+          cache: pnpm
+          node-version: lts/*
+      - run: pnpm install
       - run: pnpm format
       - run: git restore .github/workflows pnpm-lock.yaml
       - uses: actions/create-github-app-token@v3


### PR DESCRIPTION
Reverts sanity-io/.github#33 as it requires pnpm v11 and not all repos are there yet, see https://github.com/sanity-io/plugins/actions/runs/29242160432/job/86790500798