### PR TITLE
feat(changesets): support releasing from maintenance branches

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -114,15 +114,21 @@ jobs:
 
       # Demoting a release after the fact is not an option: unmarking "Latest" does not promote
       # the previous release back, so it has to be correct at creation time.
+      #
+      # Deliberately not gated on `steps.changesets.outputs.published`. That output is only true
+      # when `changeset publish` reported a new tag, so if the job died after npm had accepted
+      # the package, a rerun would report false and this step would never create the release,
+      # leaving a published version with no release and no way to recover short of doing it by
+      # hand. Keying off unreleased tags on the release commit instead makes a rerun repair it.
       - name: Create GitHub releases without marking them latest
-        if: ${{ !inputs.githubReleaseLatest && steps.changesets.outputs.published == 'true' }}
+        if: ${{ !inputs.githubReleaseLatest }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
 
           # `changeset publish` tags locally, and with createGithubReleases disabled the action
-          # does not push them. Tags it just created are the ones pointing at HEAD.
+          # does not push them. Tags it created are the ones pointing at HEAD.
           tags="$(git tag --points-at HEAD)"
           if [ -z "$tags" ]; then
             echo "No tags at HEAD, nothing to release"
@@ -139,6 +145,10 @@ jobs:
           import {existsSync, readFileSync} from 'node:fs'
           import {join} from 'node:path'
 
+          // Exit code reserved for "this tag is not something we should release", as opposed to
+          // a genuine failure, so the caller can skip it rather than fail the run.
+          const SKIP = 3
+
           const [, , tag, packagesPath] = process.argv
           const packages = JSON.parse(readFileSync(packagesPath, 'utf8'))
 
@@ -151,33 +161,82 @@ jobs:
           const pkg = name
             ? packages.find((p) => p.name === name)
             : (packages.find((p) => p.path === process.cwd()) ?? packages[0])
-          if (!pkg) throw new Error(`Could not find the package for tag ${tag}`)
+          if (!pkg) {
+            console.error(`No package in this repo matches tag ${tag}`)
+            process.exit(SKIP)
+          }
 
+          // Changelogs can be turned off. changesets/action skips the release entirely in that
+          // case, so do the same rather than publishing an empty one.
           const changelogPath = join(pkg.path, 'CHANGELOG.md')
-          // Changelogs can be turned off, in which case there are simply no notes.
-          if (!existsSync(changelogPath)) process.exit(0)
+          if (!existsSync(changelogPath)) {
+            console.error(`No CHANGELOG.md in ${pkg.path}`)
+            process.exit(SKIP)
+          }
 
-          const isHeading = (line) => line.startsWith('## ')
+          const lines = readFileSync(changelogPath, 'utf8').split('\n')
+
+          // A `## ` line inside a fenced code block is not a heading. changesets/action parses
+          // the changelog as markdown and gets this for free; here the fences are tracked by
+          // hand, otherwise a code sample in an entry would truncate the notes.
+          let fence = null
+          const isHeading = lines.map((line) => {
+            const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/)
+            if (fence !== null) {
+              if (
+                fenceMatch &&
+                fenceMatch[1][0] === fence[0] &&
+                fenceMatch[1].length >= fence.length
+              ) {
+                fence = null
+              }
+              return false
+            }
+            if (fenceMatch) {
+              fence = fenceMatch[1]
+              return false
+            }
+            return line.startsWith('## ')
+          })
+
           const headingVersion = (line) =>
             line.slice(3).trim().split(/\s+/)[0].replace(/^\[/, '').replace(/\].*$/, '')
 
-          const lines = readFileSync(changelogPath, 'utf8').split('\n')
-          const start = lines.findIndex((l) => isHeading(l) && headingVersion(l) === version)
+          const start = lines.findIndex((line, i) => isHeading[i] && headingVersion(line) === version)
           if (start === -1) {
             throw new Error(`No changelog entry for ${version} in ${changelogPath}`)
           }
 
-          const rest = lines.slice(start + 1)
-          const end = rest.findIndex(isHeading)
-          console.log((end === -1 ? rest : rest.slice(0, end)).join('\n').trim())
+          let end = lines.length
+          for (let i = start + 1; i < lines.length; i++) {
+            if (isHeading[i]) {
+              end = i
+              break
+            }
+          }
+
+          console.log(lines.slice(start + 1, end).join('\n').trim())
           NOTES_EOF
 
           for tag in $tags; do
+            # Also the idempotency guard that lets a rerun finish a partially failed release.
             if gh release view "$tag" >/dev/null 2>&1; then
               echo "Release $tag already exists, skipping"
               continue
             fi
 
+            status=0
+            node "$RUNNER_TEMP/release-notes.mjs" "$tag" "$RUNNER_TEMP/packages.json" \
+              > "$RUNNER_TEMP/notes.md" || status=$?
+            if [ "$status" -eq 3 ]; then
+              echo "Skipping $tag"
+              continue
+            elif [ "$status" -ne 0 ]; then
+              echo "Failed to build release notes for $tag"
+              exit "$status"
+            fi
+
+            # No-op when the tag is already on the remote, which it will be on a rerun.
             git push "$remote" "refs/tags/${tag}"
 
             case "$tag" in
@@ -185,9 +244,6 @@ jobs:
               v*) version="${tag#v}" ;;
               *) version="$tag" ;;
             esac
-
-            node "$RUNNER_TEMP/release-notes.mjs" "$tag" "$RUNNER_TEMP/packages.json" \
-              > "$RUNNER_TEMP/notes.md"
 
             prerelease=()
             case "$version" in *-*) prerelease=(--prerelease) ;; esac

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -17,6 +17,16 @@ on:
         description: "Commit message for the version bump commit. Recommend matching versionPrTitle when overriding it."
         type: string
         default: "Version Packages"
+      npmTag:
+        required: false
+        description: "npm dist-tag to publish under. On a maintenance branch for an older major set this to e.g. 'latest-v7', so releases from it do not take 'latest' from the current major. Note that npm rejects a dist-tag that parses as a semver range, so 'v7', '7' and '7.x' are all invalid."
+        type: string
+        default: "latest"
+      githubReleaseLatest:
+        required: false
+        description: "Whether the GitHub release should be marked as 'Latest'. Set to false on a maintenance branch, otherwise a patch for an older major takes the badge from the current major."
+        type: boolean
+        default: true
     secrets:
       ECOSPARK_APP_ID:
         required: true
@@ -88,10 +98,105 @@ jobs:
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          publish: pnpm release
+          # Only append --tag when it is not the default, so the publish command stays byte for
+          # byte what it was for every caller that has not opted in.
+          publish: ${{ inputs.npmTag == 'latest' && 'pnpm release' || format('pnpm release --tag {0}', inputs.npmTag) }}
           title: ${{ inputs.versionPrTitle }}
           commit: ${{ inputs.versionCommitMessage }}
           setupGitUser: false
+          # The action creates releases without `make_latest`, so GitHub marks whichever was
+          # created most recently as "Latest". When that is not wanted we skip its release
+          # creation and do it ourselves in the next step.
+          createGithubReleases: ${{ inputs.githubReleaseLatest }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}
+
+      # Demoting a release after the fact is not an option: unmarking "Latest" does not promote
+      # the previous release back, so it has to be correct at creation time.
+      - name: Create GitHub releases without marking them latest
+        if: ${{ !inputs.githubReleaseLatest && steps.changesets.outputs.published == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          # `changeset publish` tags locally, and with createGithubReleases disabled the action
+          # does not push them. Tags it just created are the ones pointing at HEAD.
+          tags="$(git tag --points-at HEAD)"
+          if [ -z "$tags" ]; then
+            echo "No tags at HEAD, nothing to release"
+            exit 0
+          fi
+
+          # checkout ran with persist-credentials: false, so push over an explicitly
+          # authenticated remote rather than relying on stored credentials.
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          pnpm list --recursive --depth -1 --json > "$RUNNER_TEMP/packages.json"
+
+          cat > "$RUNNER_TEMP/release-notes.mjs" <<'NOTES_EOF'
+          import {existsSync, readFileSync} from 'node:fs'
+          import {join} from 'node:path'
+
+          const [, , tag, packagesPath] = process.argv
+          const packages = JSON.parse(readFileSync(packagesPath, 'utf8'))
+
+          // changesets tags a single-package repo as `v1.2.3`, and each package in a workspace
+          // as `name@1.2.3`, including scoped names like `@sanity/client@1.2.3`.
+          const at = tag.lastIndexOf('@')
+          const name = at > 0 ? tag.slice(0, at) : null
+          const version = at > 0 ? tag.slice(at + 1) : tag.replace(/^v/, '')
+
+          const pkg = name
+            ? packages.find((p) => p.name === name)
+            : (packages.find((p) => p.path === process.cwd()) ?? packages[0])
+          if (!pkg) throw new Error(`Could not find the package for tag ${tag}`)
+
+          const changelogPath = join(pkg.path, 'CHANGELOG.md')
+          // Changelogs can be turned off, in which case there are simply no notes.
+          if (!existsSync(changelogPath)) process.exit(0)
+
+          const isHeading = (line) => line.startsWith('## ')
+          const headingVersion = (line) =>
+            line.slice(3).trim().split(/\s+/)[0].replace(/^\[/, '').replace(/\].*$/, '')
+
+          const lines = readFileSync(changelogPath, 'utf8').split('\n')
+          const start = lines.findIndex((l) => isHeading(l) && headingVersion(l) === version)
+          if (start === -1) {
+            throw new Error(`No changelog entry for ${version} in ${changelogPath}`)
+          }
+
+          const rest = lines.slice(start + 1)
+          const end = rest.findIndex(isHeading)
+          console.log((end === -1 ? rest : rest.slice(0, end)).join('\n').trim())
+          NOTES_EOF
+
+          for tag in $tags; do
+            if gh release view "$tag" >/dev/null 2>&1; then
+              echo "Release $tag already exists, skipping"
+              continue
+            fi
+
+            git push "$remote" "refs/tags/${tag}"
+
+            case "$tag" in
+              *@*) version="${tag##*@}" ;;
+              v*) version="${tag#v}" ;;
+              *) version="$tag" ;;
+            esac
+
+            node "$RUNNER_TEMP/release-notes.mjs" "$tag" "$RUNNER_TEMP/packages.json" \
+              > "$RUNNER_TEMP/notes.md"
+
+            prerelease=()
+            case "$version" in *-*) prerelease=(--prerelease) ;; esac
+
+            echo "Creating release $tag (latest=false)"
+            gh release create "$tag" \
+              --title "$tag" \
+              --notes-file "$RUNNER_TEMP/notes.md" \
+              --latest=false \
+              --verify-tag \
+              "${prerelease[@]}"
+          done


### PR DESCRIPTION
Closes #38.

Lets a repo that keeps an older major alive release from a maintenance branch without that release taking over the two defaults that should belong to the current major.

## Inputs

- `npmTag` (string, default `latest`) is passed through as `changeset publish --tag`, so a 7.x patch lands on `latest-v7` rather than `latest`.
- `githubReleaseLatest` (boolean, default `true`). When false the workflow creates the GitHub release itself with `--latest=false`.

A caller on a maintenance branch then passes:

```yaml
with:
  npmTag: latest-v7
  githubReleaseLatest: false
```

The tag cannot just be `v7`. npm rejects a dist-tag that parses as a semver range, and `v7`, `7` and `7.x` all parse as `>=7.0.0 <8.0.0`. pnpm itself uses `latest-10`, `latest-9` and so on for the same reason.

## Why the GitHub half needs its own step

`changesets/action` calls `repos.createRelease` without `make_latest`, so GitHub marks whichever release was created most recently as "Latest", and a 7.x patch steals the badge from 8.0.0. There is no input to control it. Fixing it after the fact does not work either: unmarking a release does not promote the previous one back, so it has to be right at creation time.

So when `githubReleaseLatest` is false we set `createGithubReleases: false` and create the release in a follow-up step. Two consequences worth knowing, both handled:

- With that input disabled the action also stops pushing the tags `changeset publish` created locally, so the new step pushes them. It uses an explicitly authenticated remote because `actions/checkout` here runs with `persist-credentials: false`.
- The release body has to come from `CHANGELOG.md`, which is what the action's own `getChangelogEntry` does. The step resolves each tag to its package via `pnpm list --recursive`, so it works for both a single-package repo and a workspace.

## Nothing changes for existing callers

Both inputs default to current behaviour, and the publish command is only rewritten when `npmTag` is set:

```yaml
publish: ${{ inputs.npmTag == 'latest' && 'pnpm release' || format('pnpm release --tag {0}', inputs.npmTag) }}
```

That keeps `pnpm release` byte for byte identical for everyone who has not opted in, which matters because the args get appended to whatever each repo's `release` script happens to be.

## Verified

No CI in this repo runs the reusable workflow, so I checked what could be checked locally:

- The YAML parses, and the heredoc terminator still lands at column 0 after the block scalar is dedented, which is the easy thing to get wrong here.
- `bash -n` on the extracted step and `node --check` on the embedded script.
- Ran the notes extraction against fixtures for a root-tagged repo (`v7.26.3`), a scoped workspace package (`@sanity/client@8.0.0`), an unscoped one (`get-it@9.4.1`), a repo with changelogs disabled (empty notes, exit 0), and a missing version (fails loudly).
- Checked the tag to version and prerelease derivation for all of the above plus `v8.0.0-canary.1` and `@scope/pkg@2.0.0-rc.3`.
- Confirmed `pnpm release --tag x` forwards the flag cleanly, and that `core.getBooleanInput` accepts what the `createGithubReleases` expression produces.

The end-to-end path can only really be exercised by a repo adopting it. `sanity-io/client` is the intended first caller: it currently carries a local copy of this logic (sanity-io/client#1261) and can drop it once this lands.

## One behaviour difference worth flagging

If a package has no `CHANGELOG.md`, the action skips creating a release entirely. This step creates one with an empty body instead. That seemed more predictable than silently producing no release, but happy to match the action if you would rather.
